### PR TITLE
fix(agent-ready): satisfy auth.md check (PRM bearer_methods + agent_auth anonymous method)

### DIFF
--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -9,12 +9,14 @@
   "scopes_supported": [],
   "token_endpoint_auth_methods_supported": ["none"],
   "agent_auth": {
-    "_comment": "Agent-registration metadata (auth.md convention). The site has no protected resources today, so access is open and no registration is required; register_uri points to the readable instructions at /auth.md.",
+    "_comment": "Agent-registration metadata (auth.md convention). The site is public with no protected resources today: access is anonymous and requires no registration. register_uri/claim_uri point to the readable instructions at /auth.md.",
+    "skill": "https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md",
     "register_uri": "https://deepworkplan.com/auth.md",
     "auth_required": false,
-    "identity_types_supported": ["none", "anonymous"],
-    "credential_types_supported": ["none"],
-    "claims_uri": null,
-    "revocation_uri": null
+    "identity_types_supported": ["anonymous"],
+    "anonymous": {
+      "credential_types_supported": ["none"]
+    },
+    "claim_uri": "https://deepworkplan.com/auth.md"
   }
 }

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -3,5 +3,5 @@
   "resource": "https://deepworkplan.com",
   "authorization_servers": ["https://deepworkplan.com"],
   "scopes_supported": [],
-  "bearer_methods_supported": []
+  "bearer_methods_supported": ["header"]
 }


### PR DESCRIPTION
## What & why

The isitagentready scan reached **86**; the `auth.md` check still failed with *"auth.md exists but OAuth Protected Resource Metadata was not found."* Per the auth‑md SKILL (`/.well-known/agent-skills/auth-md/SKILL.md`), the issue was two missing details in the OAuth metadata (the files exist and are served as `application/json`, but their shape didn't meet the check):

1. **PRM** must include `bearer_methods_supported` containing **`header`** — ours was `[]`.
2. **`agent_auth`** must include `skill`, `register_uri`, **and a complete registration method**. Added the **Anonymous** method (the honest fit for a public, no‑auth site): `identity_types_supported: ["anonymous"]`, `anonymous.credential_types_supported`, and `claim_uri`. Also added the required `skill` field.

## Changes
- `/.well-known/oauth-protected-resource`: `bearer_methods_supported: ["header"]`.
- `/.well-known/oauth-authorization-server` → `agent_auth`: added `skill`, switched to the Anonymous registration method (`identity_types_supported`, `anonymous.credential_types_supported`, `claim_uri`).

Static `public/` JSON only — no app/runtime changes. Both files validate as JSON. Honest stubs (the site has no protected resources); access is anonymous/open.

## After merge
Deploy → re-scan isitagentready → `auth.md` should pass (API/Auth/MCP 7/7). DNS‑AID is separately just waiting on DNSSEC propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
