### PR TITLE
feat(seo): align home meta title with the context-first narrative

### DIFF
--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Deep Work Plan — turn any repository into an AI-first codebase"
+title: "Deep Work Plan — structured execution for AI coding agents"
 description: "Context matters more than models. Deep Work Plan turns any repository into a structured environment where any coding agent finishes long-horizon work."
 lastUpdated: 2026-06-03
 ---

--- a/src/content/pages/es/index.md
+++ b/src/content/pages/es/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Deep Work Plan — convierte cualquier repositorio en un código AI-first"
+title: "Deep Work Plan — ejecución estructurada para agentes de IA"
 description: "El contexto importa más que el modelo. Deep Work Plan hace de cualquier repositorio un entorno estructurado donde un agente completa trabajo de largo aliento."
 lastUpdated: 2026-06-03
 ---

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -37,7 +37,7 @@ export const en: SiteTranslations = {
   // Deep Work Plan homepage
   home: {
     meta: {
-      title: 'Deep Work Plan — turn any repository into an AI-first codebase',
+      title: 'Deep Work Plan — structured execution for AI coding agents',
       description:
         'Context matters more than models. Deep Work Plan turns any repository into a structured environment where any coding agent finishes long-horizon work.',
     },

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -37,8 +37,7 @@ export const es: SiteTranslations = {
   // Página de inicio de Deep Work Plan
   home: {
     meta: {
-      title:
-        'Deep Work Plan — convierte cualquier repositorio en un código AI-first',
+      title: 'Deep Work Plan — ejecución estructurada para agentes de IA',
       description:
         'El contexto importa más que el modelo. Deep Work Plan hace de cualquier repositorio un entorno estructurado donde un agente completa trabajo de largo aliento.',
     },


### PR DESCRIPTION
Follow-up to the merged SEO/AEO narrative PR (#5). The home meta **title** (and `og:title`) still carried the old framing *"turn any repository into an AI-first codebase"*, which showed up in link previews even after the OG image and description were refreshed.

## Change
Home meta title → the established `siteTitleFull` tagline, in both languages:

- **EN:** `Deep Work Plan — structured execution for AI coding agents`
- **ES:** `Deep Work Plan — ejecución estructurada para agentes de IA`

Updated in all four surfaces: `src/lib/translations/{en,es}.ts` and the agent endpoints `src/content/pages/{en,es}/index.md`.

## Why this title
- **Harmonizes with the new narrative** ("structured" execution) instead of the old "AI-first codebase" line.
- **Keyword-rich** ("AI coding agents") and matches the site's existing `siteTitleFull` constant.
- **Complements, not duplicates, the description** (which leads with "Context matters more than models…"). Title = search hook, description = positioning.

## Validation
- `astro:check` — 0 errors · `biome:check` — clean · `build` — 131 pages
- Verified in build output: new string appears in both `<title>` and `og:title` for EN (`/`) and ES (`/es/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)