### PR TITLE
fix(ci): release-body generator handles merges that predate the prior release

### DIFF
--- a/.github/scripts/get_github_release_log.sh
+++ b/.github/scripts/get_github_release_log.sh
@@ -1,14 +1,35 @@
-git log --pretty=oneline | sed 's/[^ ]* *//' > git_logs.txt
+# Build the release-body content: all non-merge commits since the previous
+# release marker (the auto-generated `[🤖 Deep Work Plan] New release to v…`
+# commit). Walking the linear log from HEAD and breaking at that marker is
+# fragile — commits introduced via a merged feature branch can appear AFTER
+# the marker in topological order, so the loop misses them and the body ends
+# up empty. Using `git log RANGE --no-merges` makes the collection
+# order-independent.
+
+set -euo pipefail
 
 if [[ -f "git_logs_output.txt" ]]; then
   rm git_logs_output.txt
 fi
 
-while read text_line; do
-  if [[ "$text_line" =~ "[🤖 Deep Work Plan] New release to v" ]]; then
-    break
-  fi
-  if [[ ! "$text_line" =~ "Merge branch 'main'" ]] && [[ ! "$text_line" =~ "Merge pull request" ]]; then
-    echo "🚩 $text_line" >> git_logs_output.txt
-  fi
-done < git_logs.txt
+# Find the most recent previous release marker commit. `--grep` matches the
+# distinctive auto-release subject; `-n 1` returns the latest one.
+PREV_RELEASE=$(git log --grep='\[🤖 Deep Work Plan\] New release to v' --format='%H' -n 1 || true)
+
+if [[ -n "$PREV_RELEASE" ]]; then
+  RANGE="${PREV_RELEASE}..HEAD"
+else
+  # First release ever — collect everything.
+  RANGE='HEAD'
+fi
+
+# Collect every non-merge commit subject in the range, prefixed with the
+# release-body emoji marker the workflow expects.
+git log "$RANGE" --no-merges --format='🚩 %s' > git_logs_output.txt
+
+# Fallback so the workflow never sees an empty file (which would fail the
+# `[[ ! -f git_logs_output.txt ]]` guard downstream and yield a confusing
+# "No description found" error for tidy releases like docs/CI-only PRs).
+if [[ ! -s git_logs_output.txt ]]; then
+  echo "🚩 Maintenance release" > git_logs_output.txt
+fi


### PR DESCRIPTION
## Why

PR #11's merge ([failed run](https://github.com/DailybotHQ/deepworkplan-website/actions/runs/26980487733)) couldn't produce a release because **its only non-merge commit (\`0002a0a feat(ui): lamp toggle\`) is dated *before* the previous \`v1.0.45\` release marker** — the lamp branch was created off main while PR #10 was still being reviewed, then PR #10 + the auto-release marker landed first, then PR #11 was merged.

The old script walked the linear git log from HEAD and broke at the first \`[🤖 New release to v…\` it found, skipping merge commits on the way. With this history shape:

```
f226277  Merge PR #11           ← skipped (merge)
21ed907  Merge branch 'main'    ← skipped (merge)
b61479c  Merge branch 'main'    ← skipped (merge)
146ecab  [🤖 release v1.0.45] 🚀  ← BREAK
0002a0a  feat(ui): lamp toggle  ← never reached
```

The loop produced zero lines, the file was never created, and the workflow failed with `"No description found for release body content."`

## Fix

Use `git log "$PREV_RELEASE..HEAD" --no-merges --format='🚩 %s'`. Topologically correct: every non-merge commit reachable from HEAD but not from the previous release ends up in the body, regardless of merge order. Also adds a `Maintenance release` fallback when the range is genuinely empty (docs/CI-only PRs).

## Verified locally

```bash
$ bash .github/scripts/get_github_release_log.sh && cat git_logs_output.txt
🚩 feat(ui): replace floating theme toggle with hurricane lamp in masthead
```

That's exactly the line PR #11's release should have included — and the old script missed.

## Follow-up

PR #11 was successfully merged and deployed by Cloudflare Pages (the deploy is decoupled from the release workflow). Only the GitHub Release entry is missing for v1.0.46. You can either:
- Manually publish the GitHub Release for the lamp toggle, or
- Let the next merge trigger the now-fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)