### PR TITLE
chore(dwp): pin reference skill to v2.5.0 (skills-lock.json)

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "5b6434fce12cc55e5f17e5e5f9f84b179b9cff139c2d0a4eea252c7164263bc8"
+      "computedHash": "7f00ff227f7ca11ca3432001b013e667c9265454789dc395e54900e5e2442f24"
     }
   }
 }


### PR DESCRIPTION
## What

Completes the skill sync to **v2.5.0** for this repo's dogfooded install.

The official DeepWorkPlan skill is installed under `.agents/skills/deepworkplan/` as a **reference install** — the skill source is **gitignored** (`.gitignore:52`), never vendored. What's committed is **`skills-lock.json`**, which pins the install so it's reproducible (`npx skills install`). This PR updates that pin to the latest published skill.

## Change
- **`skills-lock.json`** — `computedHash` `5b6434…` → `7f00ff…`, pinning `DailybotHQ/deepworkplan-skill` at **v2.5.0**.

That brings the reference install up to date with:
- the **16 new stack presets** (FastAPI, NestJS, Spring Boot, Rails, Laravel, Next.js, SvelteKit, Nuxt, Angular, React Native, Flutter, Swift/iOS, Rust, Go, Terraform, TS Lambda), and
- the newly-required **`PRODUCT_SPEC.md`** docs category (MUST, all archetypes).

## How / verification
- Regenerated with `npx skills update` (not a hand-edited hash).
- Local install refreshed to 2.5.0 in step: version `2.5.0`, 22 presets present, `PRODUCT_SPEC` in the standard + `verify` check. The install itself is gitignored, so it does not appear in the diff — **only the lock pin is committed** (by design).
- `skills-lock.json` valid JSON; `biome` ✅.

## Note
This is the reproducibility pin only. Anyone cloning runs `npx skills install` (or `update`) to materialize the gitignored `.agents/skills/deepworkplan/` at the pinned 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)