### PR TITLE
fix(agent-ready): non-empty scopes_supported so auth.md PRM check passes

### DIFF
--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -6,7 +6,7 @@
   "jwks_uri": "https://deepworkplan.com/.well-known/jwks.json",
   "grant_types_supported": ["authorization_code"],
   "response_types_supported": ["code"],
-  "scopes_supported": [],
+  "scopes_supported": ["read"],
   "token_endpoint_auth_methods_supported": ["none"],
   "agent_auth": {
     "_comment": "Agent-registration metadata (auth.md convention). The site is public with no protected resources today: access is anonymous and requires no registration. register_uri/claim_uri point to the readable instructions at /auth.md.",

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,7 +1,7 @@
 {
-  "_comment": "deepworkplan.com is a static content site with no OAuth-protected resources today. This document is published for agent-readiness compliance per RFC 9728. The authorization_servers entry self-references the site's own OAuth authorization-server metadata (also a stub).",
+  "_comment": "deepworkplan.com is a static content site with no OAuth-protected resources today. This document is published for agent-readiness compliance per RFC 9728. The authorization_servers entry self-references the site's own OAuth authorization-server metadata (also a stub). 'read' is the only scope and maps to anonymous read-only access to public content; no token is actually required.",
   "resource": "https://deepworkplan.com",
   "authorization_servers": ["https://deepworkplan.com"],
-  "scopes_supported": [],
+  "scopes_supported": ["read"],
   "bearer_methods_supported": ["header"]
 }


### PR DESCRIPTION
## Why

isitagentready.com scores deepworkplan.com at **6/7** on "API, Auth, MCP & Skill Discovery" — the one failing point is `authMd`:

> auth.md exists but OAuth Protected Resource Metadata was not found

Pulling the live scan evidence showed the real cause: the `authMd` check uses a **stricter PRM validator** than the standalone `oauthProtectedResource` check (which passes). It rejects an empty `scopes_supported` array:

```
[validate] Validate Protected Resource Metadata
  finding [negative]: Missing scopes_supported array
```

The PRM had `"scopes_supported": []` — present but empty, which the validator counts as missing.

## What

Give `scopes_supported` one honest entry — `"read"` (anonymous read-only access to public content; no token actually required) — in both:

- `public/.well-known/oauth-protected-resource`
- `public/.well-known/oauth-authorization-server` (mirrored for consistency)

Flips the discovery category from **6/7 → 7/7**. No other behavior change; the site remains public/anonymous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)