### PR TITLE
fix(agent-ready): point agent_auth.skill to own /auth.md (last auth.md point)

### DIFF
--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -9,8 +9,8 @@
   "scopes_supported": ["read"],
   "token_endpoint_auth_methods_supported": ["none"],
   "agent_auth": {
-    "_comment": "Agent-registration metadata (auth.md convention). The site is public with no protected resources today: access is anonymous and requires no registration. register_uri/claim_uri point to the readable instructions at /auth.md.",
-    "skill": "https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md",
+    "_comment": "Agent-registration metadata (auth.md convention; see https://workos.com/auth-md). Per the spec, 'skill' points to this service's own /auth.md procedural doc. The site is public with no protected resources today: access is anonymous and requires no registration. register_uri/claim_uri point to the readable instructions at /auth.md.",
+    "skill": "https://deepworkplan.com/auth.md",
     "register_uri": "https://deepworkplan.com/auth.md",
     "auth_required": false,
     "identity_types_supported": ["anonymous"],


### PR DESCRIPTION
## Why

After the previous fix (non-empty `scopes_supported`), the live `authMd` check advanced its PRM validation to **pass**, then failed at the next step:

```
[validate] Validate agent_auth.skill
  negative: Missing or unsafe skill URL pointing to /auth.md
```

`agent_auth.skill` pointed cross-origin to `isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md`, which the validator treats as unsafe.

## What

Per the [WorkOS auth.md spec](https://workos.com/auth-md), `skill` must reference the service's **own** `/auth.md` procedural doc. Repoint:

`agent_auth.skill` → `https://deepworkplan.com/auth.md`

This is the last failing point on "API, Auth, MCP & Skill Discovery" (6/7 → 7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)