### PR TITLE
fix(docker): pin /usr/local/bin first in PATH for all shell types

### DIFF
--- a/docker/custom_commands.sh
+++ b/docker/custom_commands.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Container-installed Node must win over IDE-bundled Node (Cursor Server's
+# ~/.cursor-server/bin/<commit>/node, VS Code Server's equivalent, etc.).
+# /etc/profile.d/00-container-node-first.sh covers login shells; this guard
+# covers non-login interactive shells that only source ~/.bashrc (editor
+# terminals, `bash -i`, the agent shell tool, …). Idempotent.
+if [ -x /usr/local/bin/node ]; then
+  case "${PATH}" in
+    /usr/local/bin:*) : ;;  # already at the front
+    *) PATH="/usr/local/bin:${PATH}" ;;
+  esac
+  export PATH
+fi
+
 function print.success {
 	GREEN="\033[0;32m"
   RESET="\033[0m"

--- a/docker/local/dwpwebsite/Dockerfile
+++ b/docker/local/dwpwebsite/Dockerfile
@@ -46,6 +46,25 @@ RUN mkdir -p "${PNPM_HOME}/bin" \
 # Make node user's CLI install dirs available on PATH (pnpm globals, Claude, Cursor agent)
 ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:/home/node/.local/bin:/home/node/.cursor/bin:$PATH
 
+# Ensure the container's image-installed Node (/usr/local/bin) precedes any
+# IDE-bundled Node that gets prepended to PATH at shell startup — Cursor Server
+# (~/.cursor-server/bin/<commit>/node), VS Code Server, etc. Without this,
+# `node`/`npx`/`pnpm` in agent shells resolve to the IDE's bundled binary
+# (an older LTS) even though `FROM node:<X>-...` installs the right one.
+# Login shells source /etc/profile.d/*; this is the most universal anchor.
+RUN printf '%s\n' \
+    '# Container-installed Node must win over IDE-bundled Node (Cursor Server, etc.).' \
+    '# This drop-in is idempotent and safe for any POSIX-ish shell.' \
+    'if [ -x /usr/local/bin/node ]; then' \
+    '  case "${PATH}" in' \
+    '    /usr/local/bin:*) : ;;  # already at the front' \
+    '    *) PATH="/usr/local/bin:${PATH}" ;;' \
+    '  esac' \
+    '  export PATH' \
+    'fi' \
+    > /etc/profile.d/00-container-node-first.sh \
+    && chmod 0644 /etc/profile.d/00-container-node-first.sh
+
 # Redirect any `npm` invocation to pnpm — this repo uses pnpm exclusively,
 # so running npm would corrupt node_modules and pnpm-lock.yaml. Replace the
 # real npm symlink at /usr/local/bin/npm (always in PATH, regardless of how


### PR DESCRIPTION
## Summary

Cursor Server (and VS Code Server) prepend their own bundled `node` binary to `PATH` when they attach to the container. That shadowed the container's `FROM node:24.15.0-trixie-slim` install in every shell — `node` resolved to **v20.18.2** instead of **v24.15.0**, which broke:

- **corepack pnpm 11.x** → `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` (only in Node 22+), so `pnpm run i18n:check`, `md:check`, `build`, etc. all failed.
- **Astro** → `Node.js v20.18.2 is not supported by Astro! Please upgrade to >=22.12.0`.

This is environmental (PATH ordering), not a repo bug. The fix makes the container's `/usr/local/bin` win in every shell type, without touching the IDE's own remote-server node.

## Changes (two layers, because shells take different code paths)

- **`docker/local/dwpwebsite/Dockerfile`** — adds a `/etc/profile.d/00-container-node-first.sh` drop-in (covers login shells: Cursor Server, `ssh`, `bash -l`). Sorted first (`00-`) and created while still `root`.
- **`docker/custom_commands.sh`** — mirrors the same guard at the top of the file already sourced by `~/.bashrc` (covers non-login interactive shells: editor terminals, `bash -i`, the agent shell tool).

The guard matches against the raw `${PATH}` (not `":${PATH}:"`) so it is **genuinely idempotent** — re-sourcing 10× leaves no PATH drift. It is a no-op if `/usr/local/bin/node` is ever absent. Cursor Server's bundled node is left untouched (it legitimately needs its own for the IDE protocol).

## Verification (no rebuild required)

Sourced each patched file in a clean subshell mimicking the IDE's prepended PATH:

```
before: ~/.cursor-server/bin/<commit>/node -> v20.18.2
after:  /usr/local/bin/node               -> v24.15.0
pnpm:   /usr/local/bin/pnpm               -> 11.1.2
```

Idempotency: sourcing 10× keeps `/usr/local/bin` at the head with no drift. `bash -n` clean.

## Notes

- Takes effect **per-container on next rebuild** (or immediately in any newly sourced shell). This same edit must be repeated in any other repo with the same shadowing issue; a shared `dailybothq/dev-base:node24` base image with the fix baked in would be a single source of truth.

## Test plan

- [ ] Rebuild the dev container; open a new editor terminal → `node --version` shows v24.15.0.
- [ ] `command -v node` resolves to `/usr/local/bin/node`.
- [ ] `pnpm run build` and `pnpm run i18n:check` succeed without the `node:sqlite` error.

Made with [Cursor](https://cursor.com)