### PR TITLE
chore: pin latest DWP (2.14.1) + dailybot (1.7.1) skills in skills-lock.json

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "dailybot": {
+      "source": "DailybotHQ/agent-skill",
+      "sourceType": "github",
+      "skillPath": "skills/dailybot/SKILL.md",
+      "computedHash": "9d6c680b0dc9a0738020fc5c2dc0fe570eb31003af16058e1f47acf11da5fa9e"
+    },
     "deepworkplan": {
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "7f00ff227f7ca11ca3432001b013e667c9265454789dc395e54900e5e2442f24"
+      "computedHash": "c7901c442f1558e144465458c57d272adebac4cb9aec132f567ca5b4389a0db9"
     }
   }
 }


### PR DESCRIPTION
## Summary

Dogfood the latest skill releases in this repo by re-pinning `skills-lock.json` via the real `npx skills` CLI (authentic dogfooding, not hand-edited hashes).

- **deepworkplan → 2.14.1** — re-pinned (previous pin was stale, predating recent releases). 2.14.1 = the skill repo's own `docs/SECURITY.md` conformance-floor dogfood + version bump; **no new methodology/spec requirement** beyond the 2.14.0 security pillar already reflected in site content.
- **dailybot → 1.7.1** — added to the lockfile for the first time, via the DWP **dailybot addon** path (`npx skills add DailybotHQ/agent-skill`). It was installed but never pinned like deepworkplan; this gives it the same reproducible pin. Install is already at the latest release (1.7.1).

## Verification

- `npx skills` install reports `deepworkplan → 2.14.1`, `dailybot → 1.7.1`.
- Repo-level DWP conformance on 2.14.1: **11/11, 0 advisory** (incl. `docs/SECURITY.md`).
- Site content already documents dailybot **1.7.x** (team chat across Slack, Teams, Discord, Google Chat) — no content change needed.
- `grep` for `2.14.x` in `src/`/`docs/` → none; dailybot version refs already say `1.7.x`.

## Note (by design)

Full `conformance.sh` reports `NOT CONFORMANT` only because **legacy local plans under the gitignored `.dwp/`** predate the 2.14.0 three-final-task protocol (missing the *Security Review* task). These are completed, uncommitted working-state artifacts; new plans include the Security Review automatically. No retrofit is included here.

## Test plan

- [x] `skills-lock.json` pins both skills with CLI-computed hashes
- [x] Installs report the latest versions (2.14.1 / 1.7.1)
- [x] Repo-level conformance 11/11
- [x] No site content / version-reference changes required