### PR TITLE
feat(aeo): publish ARD ai-catalog manifest for agent resource discovery

### DIFF
--- a/docs/features/PUBLIC_ASSETS.md
+++ b/docs/features/PUBLIC_ASSETS.md
@@ -43,7 +43,7 @@ public/
 | `site.webmanifest` | PWA metadata and icons |
 | `openapi.json` | Machine-readable API description |
 | `_headers`, `_redirects` | Cloudflare Pages headers and redirects |
-| `.well-known/` | Agent skills, MCP, and OAuth discovery files |
+| `.well-known/` | Agent skills, ARD catalog, MCP, and OAuth discovery files |
 
 ### Fonts
 

--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -1,0 +1,62 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Deep Work Plan",
+    "identifier": "did:web:deepworkplan.com"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:deepworkplan.com:server:webmcp",
+      "displayName": "Deep Work Plan WebMCP Server",
+      "type": "application/mcp-server-card+json",
+      "url": "https://deepworkplan.com/.well-known/mcp/server-card.json",
+      "representativeQueries": [
+        "how do I make my repository AI-first with Deep Work Plan",
+        "what tools does deepworkplan.com expose to agents",
+        "open the Deep Work Plan methodology section"
+      ]
+    },
+    {
+      "identifier": "urn:air:deepworkplan.com:skills:catalog",
+      "displayName": "Agent Skills Discovery Index",
+      "type": "application/json",
+      "url": "https://deepworkplan.com/.well-known/agent-skills/index.json",
+      "representativeQueries": [
+        "which agent-readiness skills does deepworkplan.com implement",
+        "find the SKILL.md procedures this site advertises"
+      ]
+    },
+    {
+      "identifier": "urn:air:deepworkplan.com:document:llms-txt",
+      "displayName": "LLM Guidance Index (llms.txt)",
+      "type": "text/plain",
+      "url": "https://deepworkplan.com/llms.txt",
+      "representativeQueries": [
+        "what is the Deep Work Plan methodology",
+        "how does DWP differ from GitHub Spec Kit or Amazon Kiro",
+        "where can I read the full DWP specification"
+      ]
+    },
+    {
+      "identifier": "urn:air:deepworkplan.com:document:init-adoption-prompt",
+      "displayName": "DWP Adoption Prompt (/init)",
+      "type": "text/markdown",
+      "url": "https://deepworkplan.com/init.md",
+      "representativeQueries": [
+        "give me the prompt to onboard a repository with Deep Work Plan",
+        "install the Deep Work Plan agent skill in my repo",
+        "what is the canonical /init endpoint for DWP"
+      ]
+    },
+    {
+      "identifier": "urn:air:deepworkplan.com:catalog:api-linkset",
+      "displayName": "API Catalog (RFC 9727 linkset)",
+      "type": "application/linkset+json",
+      "url": "https://deepworkplan.com/.well-known/api-catalog",
+      "representativeQueries": [
+        "where is the machine-readable catalog of deepworkplan.com",
+        "list the service documents this site publishes"
+      ]
+    }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -7,9 +7,16 @@
 /es/
   Link: </.well-known/api-catalog>; rel="api-catalog"
 
-# Agent-readiness .well-known endpoints (RFC 9727, RFC 8414, RFC 9728, SEP-1649, agent-skills v0.2.0)
+# Agent-readiness .well-known endpoints (RFC 9727, RFC 8414, RFC 9728, SEP-1649, agent-skills v0.2.0, ARD ai-catalog)
 /.well-known/api-catalog
   Content-Type: application/linkset+json
+  Cache-Control: public, max-age=300, must-revalidate
+
+# ARD capability manifest (agenticresourcediscovery.org): the scanner requires
+# application/json + Access-Control-Allow-Origin: * at the origin root.
+/.well-known/ai-catalog.json
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
   Cache-Control: public, max-age=300, must-revalidate
 
 /.well-known/oauth-authorization-server

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,6 +10,9 @@ Content-Signal: ai-train=yes, search=yes, ai-input=yes
 # Sitemap location
 Sitemap: https://deepworkplan.com/sitemap-index.xml
 
+# ARD capability manifest for agents (agenticresourcediscovery.org)
+Agentmap: https://deepworkplan.com/.well-known/ai-catalog.json
+
 # LLM guidance files
 # https://deepworkplan.com/llms.txt
 # https://deepworkplan.com/llms-full.txt


### PR DESCRIPTION
## What

Publish an **ARD (Agentic Resource Discovery) capability manifest** at `/.well-known/ai-catalog.json` so agents and registries can discover deepworkplan.com's machine-readable capabilities (MCP servers, skills, documents, catalogs).

This closes the last failing check on **isitagentready.com** (96 → 100): *ARD capability manifest not found*.

- Spec: https://agenticresourcediscovery.org/ · https://github.com/Agent-Card/ai-catalog
- Scanner requirement: `Content-Type: application/json` + `Access-Control-Allow-Origin: *` at the origin root

## Manifest

`specVersion: "1.0"`, host `did:web:deepworkplan.com`, and 5 entries — every one an existing, verified capability:

| Identifier | Type | URL |
|---|---|---|
| `urn:air:deepworkplan.com:server:webmcp` | `application/mcp-server-card+json` | `/.well-known/mcp/server-card.json` |
| `urn:air:deepworkplan.com:skills:catalog` | `application/json` | `/.well-known/agent-skills/index.json` |
| `urn:air:deepworkplan.com:document:llms-txt` | `text/plain` | `/llms.txt` |
| `urn:air:deepworkplan.com:document:init-adoption-prompt` | `text/markdown` | `/init.md` |
| `urn:air:deepworkplan.com:catalog:api-linkset` | `application/linkset+json` | `/.well-known/api-catalog` |

Each entry has a `displayName`, exactly one `url`, and 2–3 `representativeQueries` (real questions an agent would ask) so registries can build semantic embeddings.

## Changes

- **`public/.well-known/ai-catalog.json`** (new) — the manifest above.
- **`public/_headers`** — serve it with `Content-Type: application/json`, `Access-Control-Allow-Origin: *`, and a 5-min cache, matching the other `.well-known` endpoints.
- **`public/robots.txt`** — optional `Agentmap:` directive (ARD spec §6.1) pointing at the manifest for crawlers that support it.
- **`docs/features/PUBLIC_ASSETS.md`** — mention the ARD catalog under `.well-known/`.

## Validation

- Manifest structure checked against the scanner rules: `specVersion` non-empty, `host` object, `urn:air:<fqdn>:<namespace>:<name>` identifiers, IANA media types, exactly-one-of `url`/`data`, 2–5 `representativeQueries` per entry ✓
- All 5 entry targets verified present in `dist/` after build ✓
- `biome:check` ✓ · `astro check` (0 errors) ✓ · build (1369 pages) ✓ · 85/85 tests ✓

## After merge

Cloudflare Pages deploys on merge; then re-scan:

```
curl -s -X POST https://isitagentready.com/api/scan -H 'Content-Type: application/json' \
  -d '{"url": "https://deepworkplan.com"}'
```

and confirm `checks.discovery.ard.status` is `"pass"` → score 100/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
