### PR TITLE
fix: llms.txt markdown links (Agentic Browsing 3/3) + robots rewrite hardening

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -26,7 +26,15 @@ console.log(pkg.version);
 TAG="v${VERSION}"
 RELEASE_MESSAGE="[🤖 Deep Work Plan] New release to ${TAG} launched 🚀"
 
+# Re-stamp the versioned agent artifacts (openapi.json, health.json, mcp
+# manifests, server card, MCP server-info) so they ship in the SAME release
+# commit. Without this, `pnpm run test` fails on a fresh checkout of main
+# after a release: package.json says vX.Y.Z+1 while the artifacts still say
+# vX.Y.Z (tests/unit/lib/openapi.test.ts enforces the parity).
+node scripts/stamp-versions.mjs
+
 git add package.json
+git add public/openapi.json public/api/health.json public/.well-known/mcp.json public/.well-known/mcp/server-card.json src/lib/mcp/server-info.ts 2>/dev/null || true
 if [[ -f "pnpm-lock.yaml" ]]; then
   git add pnpm-lock.yaml
 fi

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -187,6 +187,12 @@ const LIGHTHOUSE_UA_PATTERN = /Chrome-Lighthouse|PageSpeed|Lighthouse/i;
  * which still receives the full directive. This UA rewrite does not change
  * what search engines index; it only removes a false-positive flag from
  * one specific strict parser.
+ *
+ * LIMITATION: Cloudflare's "AI Crawl Control" managed robots.txt section is
+ * injected at the edge AFTER Functions run, so its own Content-Signal line
+ * cannot be stripped here. If the managed section is enabled, Lighthouse
+ * still sees one invalid directive — the fix is to disable the managed
+ * robots.txt in the Cloudflare dashboard (AI → AI Crawl Control).
  */
 async function tryRewriteRobotsForLighthouse(
   context: EventContext
@@ -204,8 +210,8 @@ async function tryRewriteRobotsForLighthouse(
     if (!assetResponse.ok) return null;
 
     const originalBody = await assetResponse.text();
-    // Remove the `Content-Signal: ...` directive line plus its trailing newline.
-    const rewritten = originalBody.replace(/^Content-Signal:.*\r?\n?/m, '');
+    // Remove every `Content-Signal: ...` directive line plus trailing newline.
+    const rewritten = originalBody.replace(/^Content-Signal:.*\r?\n?/gm, '');
 
     return new Response(rewritten, {
       status: 200,

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work-plan-site",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "description": "deepworkplan.com — the Deep Work Plan methodology, specification, and kit. Read-only MCP surface exposing the canonical /init adoption prompt, the site map, and every page as source Markdown.",
   "protocolVersion": "2025-06-18",
   "supportedProtocolVersions": [

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,7 +1,7 @@
 {
   "serverInfo": {
     "name": "deep-work-plan-site",
-    "version": "1.0.83",
+    "version": "1.0.84",
     "description": "deepworkplan.com — the Deep Work Plan methodology, specification, and kit. Read-only agent surface exposing the canonical /init adoption prompt, the site map, and every page as source Markdown. Served over Streamable HTTP at /api/mcp and, in the browser, via WebMCP (navigator.modelContext) on every page; documented for agents at /.well-known/agent-skills/index.json."
   },
   "transport": {

--- a/public/api/health.json
+++ b/public/api/health.json
@@ -2,7 +2,7 @@
   "status": "ok",
   "service": "deepworkplan.com",
   "description": "Deep Work Plan — methodology site with a read-only, zero-auth agent API: LLM guidance files, per-page Markdown mirrors, discovery documents, and an MCP server.",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "links": {
     "openapi": "https://deepworkplan.com/openapi.json",
     "developers": "https://deepworkplan.com/developers",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -14,14 +14,14 @@ The methodology, specification, and kit are released under the MIT license — f
 
 Reach for DWP when the job is:
 
-- Making a repository AI-first: installing the agent scaffolding (context, skills, guardrails) so any coding agent can pilot it. Start at /init.md — a self-contained prompt an agent can execute directly.
+- Making a repository AI-first: installing the agent scaffolding (context, skills, guardrails) so any coding agent can pilot it. Start with the [adoption prompt](https://deepworkplan.com/init.md) — a self-contained prompt an agent can execute directly.
 - Long-horizon agent work: features, refactors, or migrations too large for one prompt, decomposed into atomic tasks that each end in an explicit validation gate and survive across sessions (resumable state on disk).
 - Spec-driven development without tool lock-in: the plan is the durable source of truth in the repo (Markdown, version-controlled), not inside a vendor's tool. DWP is tool-agnostic where GitHub Spec Kit, Amazon Kiro, or Tessl are tool-bound.
 - Handing an unfamiliar repository to an agent: the DWP documentation layer (AGENTS.md, docs/, .agents/) gives any agent the context to work safely.
 
 Skip DWP for single-file edits, throwaway scripts, or repos an agent will touch once — the structure pays off on durable, multi-session work.
 
-How an agent should engage: fetch /init.md and follow it to onboard a repository; call the MCP tools at /api/mcp (get_init_prompt, list_site_sections, read_page) to navigate and read this site; read /developers for the full API surface.
+How an agent should engage: fetch the [adoption prompt](https://deepworkplan.com/init.md) and follow it to onboard a repository; call the MCP tools at [api/mcp](https://deepworkplan.com/api/mcp) (get_init_prompt, list_site_sections, read_page) to navigate and read this site; read the [developer portal](https://deepworkplan.com/developers) for the full API surface.
 
 ## Who Maintains It
 
@@ -40,18 +40,18 @@ Deep Work Plan grew out of real engineering work at Dailybot and is now maintain
 
 ### Pages
 
-- **Home** (/) — Overview of the Deep Work Plan methodology and how to get started
-- **Methodology** (/methodology) — The narrative methodology: what DWP is, its principles, the workflow, and how to adopt it
-- **Specification** (/spec) — The readable, normative DWP standard: task anatomy, validation gates, completion protocol, mandatory final tasks, archetypes, and addons
-- **Kit** (/kit) — The kit catalog: presets, adapters, and commands available for installing DWP into a repository
-- **Examples** (/examples) — Worked examples that show the methodology applied to real engineering work
-- **Quickstart** (/quickstart) — A short path to getting DWP running in a repository
-- **Init / Adoption** (/init) — Make any repository AI-first: install the skill, onboard the repo, then plan and execute. Includes a self-contained onboarding prompt at /init.md to hand to an agent
-- **Developers** (/developers) — The agent & developer surface: a read-only, zero-auth API described by an OpenAPI spec, a stateless MCP server at /api/mcp, per-page Markdown in 17 languages, and the `npx skills` install CLI. Alias: /docs redirects here
-- **Trust** (/trust) — Why the skill is safe to adopt: open source, MIT, verifiable installs (SHA256SUMS), and a clear vulnerability-disclosure policy
-- **About** (/about) — What Deep Work Plan is, its core principles, and who maintains it
-- **Contact** (/contact) — How to engage with the project: source, issues, and discussions on GitHub
-- **Privacy** (/privacy) — The site's privacy policy: static site, no accounts, cookieless analytics
+- [Home](https://deepworkplan.com/) — Overview of the Deep Work Plan methodology and how to get started
+- [Methodology](https://deepworkplan.com/methodology) — The narrative methodology: what DWP is, its principles, the workflow, and how to adopt it
+- [Specification](https://deepworkplan.com/spec) — The readable, normative DWP standard: task anatomy, validation gates, completion protocol, mandatory final tasks, archetypes, and addons
+- [Kit](https://deepworkplan.com/kit) — The kit catalog: presets, adapters, and commands available for installing DWP into a repository
+- [Examples](https://deepworkplan.com/examples) — Worked examples that show the methodology applied to real engineering work
+- [Quickstart](https://deepworkplan.com/quickstart) — A short path to getting DWP running in a repository
+- [Init / Adoption](https://deepworkplan.com/init) — Make any repository AI-first: install the skill, onboard the repo, then plan and execute. Includes a self-contained onboarding prompt at [init.md](https://deepworkplan.com/init.md) to hand to an agent
+- [Developers](https://deepworkplan.com/developers) — The agent & developer surface: a read-only, zero-auth API described by an OpenAPI spec, a stateless MCP server at /api/mcp, per-page Markdown in 17 languages, and the `npx skills` install CLI. Alias: /docs redirects here
+- [Trust](https://deepworkplan.com/trust) — Why the skill is safe to adopt: open source, MIT, verifiable installs (SHA256SUMS), and a clear vulnerability-disclosure policy
+- [About](https://deepworkplan.com/about) — What Deep Work Plan is, its core principles, and who maintains it
+- [Contact](https://deepworkplan.com/contact) — How to engage with the project: source, issues, and discussions on GitHub
+- [Privacy](https://deepworkplan.com/privacy) — The site's privacy policy: static site, no accounts, cookieless analytics
 
 ### Languages
 
@@ -126,24 +126,24 @@ curl -H "Accept: text/markdown" https://deepworkplan.com/methodology
 
 ## Agent API
 
-The site exposes a read-only, zero-auth agent API — no keys, no registration, declared at /auth.md:
+The site exposes a read-only, zero-auth agent API — no keys, no registration, declared in [auth.md](https://deepworkplan.com/auth.md):
 
-- **OpenAPI 3.1 spec**: /openapi.json — every endpoint, parameter, and response schema
-- **MCP server**: /api/mcp — stateless Model Context Protocol over Streamable HTTP (JSON-RPC 2.0). Tools: `get_init_prompt`, `list_site_sections`, `read_page`. Manifest: /.well-known/mcp.json; server card: /.well-known/mcp/server-card.json. Supports protocol versions 2025-03-26 and 2025-06-18
-- **Health**: /api/health.json — static status marker
-- **Developer portal**: /developers — quickstarts, curl examples, and the install CLI (`/docs` redirects there)
+- [OpenAPI 3.1 spec](https://deepworkplan.com/openapi.json) — every endpoint, parameter, and response schema
+- [MCP server](https://deepworkplan.com/api/mcp) — stateless Model Context Protocol over Streamable HTTP (JSON-RPC 2.0). Tools: `get_init_prompt`, `list_site_sections`, `read_page`. Manifest: [mcp.json](https://deepworkplan.com/.well-known/mcp.json); server card: [server-card.json](https://deepworkplan.com/.well-known/mcp/server-card.json). Supports protocol versions 2025-03-26 and 2025-06-18
+- [Health](https://deepworkplan.com/api/health.json) — static status marker
+- [Developer portal](https://deepworkplan.com/developers) — quickstarts, curl examples, and the install CLI ([/docs](https://deepworkplan.com/docs) redirects there)
 - **Errors**: unknown `/api/*` paths return structured JSON errors (`{"error":{"code","message","hint"}}`), never HTML; Markdown-negotiating clients that hit a 404 receive a Markdown recovery body listing the sitemap, llms.txt, and key pages
 
 ## Feeds & Discovery
 
-- Sitemap: /sitemap-index.xml
-- robots.txt: /robots.txt
-- API catalog (RFC 9727): /.well-known/api-catalog
-- ARD capability manifest / agentmap: /.well-known/ai-catalog.json
-- Agent Skills index: /.well-known/agent-skills/index.json
-- Security contact (RFC 9116): /.well-known/security.txt
-- This file: /llms-full.txt
-- Short version: /llms.txt
+- [Sitemap](https://deepworkplan.com/sitemap-index.xml) — every page in every language
+- [robots.txt](https://deepworkplan.com/robots.txt) — crawling rules and the Agentmap pointer
+- [API catalog](https://deepworkplan.com/.well-known/api-catalog) — RFC 9727 linkset of service documents
+- [ARD capability manifest](https://deepworkplan.com/.well-known/ai-catalog.json) — the agentmap
+- [Agent Skills index](https://deepworkplan.com/.well-known/agent-skills/index.json) — agent-readiness skills this site adopts
+- [Security contact](https://deepworkplan.com/.well-known/security.txt) — RFC 9116
+- This file: [llms-full.txt](https://deepworkplan.com/llms-full.txt)
+- Short version: [llms.txt](https://deepworkplan.com/llms.txt)
 
 ## Structured Data
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,68 +10,68 @@ Deep Work Plan is the methodology that turns any repository into an AI-first, ag
 
 Reach for DWP when the job is:
 
-- Making a repository AI-first: installing the agent scaffolding (context, skills, guardrails) so any coding agent can pilot it. Start at /init.md — a self-contained prompt an agent can execute directly.
+- Making a repository AI-first: installing the agent scaffolding (context, skills, guardrails) so any coding agent can pilot it. Start with the [adoption prompt](https://deepworkplan.com/init.md) — a self-contained prompt an agent can execute directly.
 - Long-horizon agent work: features, refactors, or migrations too large for one prompt, decomposed into atomic tasks that each end in an explicit validation gate and survive across sessions (resumable state on disk).
 - Spec-driven development without tool lock-in: the plan is the durable source of truth in the repo (Markdown, version-controlled), not inside a vendor's tool. DWP is tool-agnostic where GitHub Spec Kit, Amazon Kiro, or Tessl are tool-bound.
 - Handing an unfamiliar repository to an agent: the DWP documentation layer (AGENTS.md, docs/, .agents/) gives any agent the context to work safely.
 
 Skip DWP for single-file edits, throwaway scripts, or repos an agent will touch once — the structure pays off on durable, multi-session work.
 
-How an agent should engage: fetch /init.md and follow it to onboard a repository; call the MCP tools at /api/mcp (get_init_prompt, list_site_sections, read_page) to navigate and read this site; read /developers for the full API surface.
+How an agent should engage: fetch the [adoption prompt](https://deepworkplan.com/init.md) and follow it to onboard a repository; call the MCP tools at [api/mcp](https://deepworkplan.com/api/mcp) (get_init_prompt, list_site_sections, read_page) to navigate and read this site; read the [developer portal](https://deepworkplan.com/developers) for the full API surface.
 
 ## Core Sections
 
-- Home: /
-- Methodology: /methodology — what DWP is, its principles, and how to adopt it
-- Specification: /spec — the normative DWP standard (task anatomy, validation gates, completion protocol, archetypes, addons)
-- Kit: /kit — presets, adapters, and commands for installing DWP into a repository
-- Examples: /examples — worked examples of the methodology in practice
-- Quickstart: /quickstart — get DWP running in a repo quickly
-- Init / Adoption: /init — make any repository AI-first: install the skill, onboard the repo, then plan and execute. Self-contained agent prompt at /init.md
-- Developers: /developers — the agent & developer surface: OpenAPI spec, MCP server, zero-auth API, install CLI
-- Trust: /trust — why the skill is safe to adopt: MIT, verifiable installs, disclosure policy
-- About: /about — what DWP is and who maintains it (Dailybot)
-- Contact: /contact — how to engage with the project on GitHub
-- Privacy: /privacy — the site's privacy policy
-
-## Repository
-
-- GitHub: https://github.com/DailybotHQ/deepworkplan-website
+- [Home](https://deepworkplan.com/): overview of the Deep Work Plan methodology
+- [Methodology](https://deepworkplan.com/methodology): what DWP is, its principles, and how to adopt it
+- [Specification](https://deepworkplan.com/spec): the normative DWP standard — task anatomy, validation gates, completion protocol, archetypes, addons
+- [Kit](https://deepworkplan.com/kit): presets, adapters, and commands for installing DWP into a repository
+- [Examples](https://deepworkplan.com/examples): worked examples of the methodology in practice
+- [Quickstart](https://deepworkplan.com/quickstart): get DWP running in a repo quickly
+- [Init / Adoption](https://deepworkplan.com/init): make any repository AI-first — install the skill, onboard the repo, then plan and execute (self-contained agent prompt at [init.md](https://deepworkplan.com/init.md))
+- [Developers](https://deepworkplan.com/developers): the agent & developer surface — OpenAPI spec, MCP server, zero-auth API, install CLI
+- [Trust](https://deepworkplan.com/trust): why the skill is safe to adopt — MIT, verifiable installs, disclosure policy
+- [About](https://deepworkplan.com/about): what DWP is and who maintains it (Dailybot)
+- [Contact](https://deepworkplan.com/contact): how to engage with the project on GitHub
+- [Privacy](https://deepworkplan.com/privacy): the site's privacy policy
 
 ## Developer & Agent Resources
 
-All public, read-only, and zero-auth (no API keys, no registration) — declared at /auth.md:
+All public, read-only, and zero-auth (no API keys, no registration) — declared in [auth.md](https://deepworkplan.com/auth.md):
 
-- OpenAPI spec: /openapi.json — every endpoint, parameter, and response schema of the agent API
-- MCP server: /api/mcp — Streamable HTTP (JSON-RPC 2.0); manifest at /.well-known/mcp.json
-- Health: /api/health.json
-- API catalog (RFC 9727): /.well-known/api-catalog
-- ARD capability manifest (agentmap): /.well-known/ai-catalog.json
-- Agent Skills index: /.well-known/agent-skills/index.json
-- Security contact: /.well-known/security.txt
-- Developer portal: /developers (redirect: /docs → /developers)
-- Install CLI: `npx skills add DailybotHQ/deepworkplan-skill@latest`
+- [OpenAPI spec](https://deepworkplan.com/openapi.json): every endpoint, parameter, and response schema of the agent API
+- [MCP server](https://deepworkplan.com/api/mcp): Streamable HTTP (JSON-RPC 2.0) — manifest at [mcp.json](https://deepworkplan.com/.well-known/mcp.json)
+- [Health](https://deepworkplan.com/api/health.json): static health marker for the agent API
+- [API catalog](https://deepworkplan.com/.well-known/api-catalog): RFC 9727 linkset of service documents
+- [ARD capability manifest](https://deepworkplan.com/.well-known/ai-catalog.json): the agentmap declared in robots.txt
+- [Agent Skills index](https://deepworkplan.com/.well-known/agent-skills/index.json): agent-readiness skills this site adopts
+- [Security contact](https://deepworkplan.com/.well-known/security.txt): where to report vulnerabilities
+- [Developer portal](https://deepworkplan.com/developers): quickstarts, curl examples, install CLI (/docs redirects here)
+
+## Repository
+
+- [deepworkplan-website](https://github.com/DailybotHQ/deepworkplan-website): this site's source (the repo dogfoods DWP)
+- [deepworkplan-skill](https://github.com/DailybotHQ/deepworkplan-skill): the installable DWP skill
 
 ## Languages
 
-The site ships in 17 languages — English (default) at the root and 16 more under their code (`/es/`, `/pt/`, `/zh/`, `/ja/`, `/de/`, `/fr/`, `/ko/`, `/ru/`, `/it/`, `/tr/`, `/id/`, `/vi/`, `/hi/`, `/pl/`, `/uk/`, `/th/`). Every page and its Markdown mirror exist in every language.
+The site ships in 17 languages — English (default) at the root and 16 more under their code. Every page and its Markdown mirror exist in every language:
+
+- [English](https://deepworkplan.com/) (default), [Spanish](https://deepworkplan.com/es/), [Portuguese](https://deepworkplan.com/pt/), [Chinese](https://deepworkplan.com/zh/), [Japanese](https://deepworkplan.com/ja/), [German](https://deepworkplan.com/de/), [French](https://deepworkplan.com/fr/), [Korean](https://deepworkplan.com/ko/), [Russian](https://deepworkplan.com/ru/), [Italian](https://deepworkplan.com/it/), [Turkish](https://deepworkplan.com/tr/), [Indonesian](https://deepworkplan.com/id/), [Vietnamese](https://deepworkplan.com/vi/), [Hindi](https://deepworkplan.com/hi/), [Polish](https://deepworkplan.com/pl/), [Ukrainian](https://deepworkplan.com/uk/), [Thai](https://deepworkplan.com/th/)
 
 ## Agent-Friendly Markdown
 
-Every rendered page is available as native source Markdown for AI agents:
+Every rendered page is available as native source Markdown for AI agents (not HTML-to-Markdown conversion):
 
-- Page Markdown: /{page}.md (EN), /es/{page}.md (ES)
-- Onboarding prompt: /init.md — a self-contained prompt you can paste into an agent to make a repository AI-first
-- Content Negotiation: send `Accept: text/markdown` to get Markdown for any page
-- Content-Type: text/markdown; charset=utf-8
-- Source Markdown — not HTML-to-Markdown conversion
+- Page Markdown: [about.md](https://deepworkplan.com/about.md) (EN), [es/about.md](https://deepworkplan.com/es/about.md) (ES) — same pattern for every page and language
+- Onboarding prompt: [init.md](https://deepworkplan.com/init.md) — a self-contained prompt you can paste into an agent to make a repository AI-first
+- Content negotiation: send `Accept: text/markdown` on any URL to receive Markdown instead of HTML (Content-Type: text/markdown; charset=utf-8)
 
 ## Machine-Readable Feeds
 
-- Sitemap: /sitemap-index.xml
-- OpenAPI spec: /openapi.json
-- Agentmap: /.well-known/ai-catalog.json
-- API catalog: /.well-known/api-catalog
+- [Sitemap](https://deepworkplan.com/sitemap-index.xml): every page in every language
+- [OpenAPI spec](https://deepworkplan.com/openapi.json): the typed agent API surface
+- [Agentmap](https://deepworkplan.com/.well-known/ai-catalog.json): ARD capability manifest
+- [API catalog](https://deepworkplan.com/.well-known/api-catalog): RFC 9727 linkset
 
 ## Crawling Guidance
 
@@ -81,4 +81,4 @@ Every rendered page is available as native source Markdown for AI agents:
 
 ## Detailed Version
 
-For comprehensive content descriptions, see: /llms-full.txt
+For comprehensive content descriptions, see: [llms-full.txt](https://deepworkplan.com/llms-full.txt)

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
   "info": {
     "title": "Deep Work Plan Agent API",
-    "version": "1.0.83",
+    "version": "1.0.84",
     "summary": "Read-only, zero-auth agent surface for deepworkplan.com: LLM guidance files, per-page Markdown mirrors in 17 languages, machine-readable discovery documents, and a stateless MCP server.",
     "description": "The Deep Work Plan (DWP) methodology site exposes a public, read-only, zero-auth surface built for AI agents. No API keys, no OAuth, no registration: every endpoint is anonymous GET except the MCP endpoint, which is POST.\n\n**When to use this API:** fetch the canonical adoption prompt (`/init.md`) to make any repository AI-first with DWP; read any page as native source Markdown (`Accept: text/markdown` or explicit `.md` URLs) in 17 languages; discover the site map via `llms.txt`, the sitemap, or the ARD catalog; and drive the site programmatically through the MCP server at `/api/mcp` (tools: `get_init_prompt`, `list_site_sections`, `read_page`).\n\n**When not to use it:** this is a documentation/marketing site — there are no write operations, user accounts, or telemetry endpoints. Do not look for them here.\n\nErrors: unknown `/api/*` paths return a structured JSON error (`ApiError`), never HTML. Non-API paths return the HTML 404 page (or a Markdown recovery body when `Accept: text/markdown` is sent).",
     "contact": {

--- a/src/lib/mcp/server-info.ts
+++ b/src/lib/mcp/server-info.ts
@@ -12,7 +12,7 @@
 export const SERVER_NAME = 'deep-work-plan-site';
 
 /** Keep in sync with package.json — stamped automatically by prebuild. */
-export const SITE_VERSION = '1.0.83';
+export const SITE_VERSION = '1.0.84';
 
 /**
  * MCP protocol revisions this server understands. A client may negotiate any


### PR DESCRIPTION
# Restore PageSpeed SEO 100 + Agentic Browsing 3/3

Follow-up to #53 (merged, v1.0.84). Two PageSpeed/Lighthouse regressions + one hardening:

## 1. Agentic Browsing: llms.txt audit — FIXED HERE

Lighthouse 13's `llms-txt` audit failed with **"File does not appear to contain any links"** (its check is `/\[.+\]\(.+\)/` on the file; our lists were plain text).

- `public/llms.txt` and `public/llms-full.txt` reformatted to the [llmstxt.org](https://llmstxt.org/) convention: every list entry is now `- [Title](absolute-url): description` (33 / 27 links).
- Verified against the audit's exact regexes and end-to-end with `lighthouse@latest --only-categories=agentic-browsing` on a local build: **3/3 scored audits pass** (`llms-txt`, `agent-accessibility-tree`, `cumulative-layout-shift` = 0). The `webmcp-*` audits are N/A in headless CLI runs.
- No content was removed — same sections (incl. When to use), same crawling guidance, just proper link syntax (which also makes the file genuinely more useful to LLMs).

## 2. SEO 92 → robots.txt "1 error" — REQUIRES DASHBOARD ACTION (not fixable in code)

Diagnosed live: our edge middleware rewrite DOES fire for Lighthouse UAs (`x-robots-rewrite: lighthouse` present, the site section's `Content-Signal` is stripped). The surviving error is the **`Content-Signal` line inside the "Cloudflare Managed" section that AI Crawl Control injects at the edge AFTER Functions run** — no code layer can remove it.

Fix in the Cloudflare dashboard (zone `deepworkplan.com`): **AI → AI Crawl Control → allow AI crawlers / disable the managed robots.txt section**. This is the same toggle that unblocks ClaudeBot/GPTBot/etc. (403 today) for the Is Agentic scan items 1-2. Once the managed section is gone, SEO returns to 100 — the middleware already handles our own directive.

Code-side hardening included here: the Lighthouse rewrite now strips **all** `Content-Signal` lines (global regex, was first-match-only) and the middleware documents the injection limitation.

## 3. CSS animations note

The screenshot item about CSS tween animations is informational — no such audit exists in the current agentic-browsing category (verified against lighthouse 13.4.1: only `llms-txt` failed; CLS is 0 and the typewriter/chevron animations already respect `prefers-reduced-motion`). No visual behavior changed in this PR.

## Test plan

- [x] `pnpm run test` (127) · `pnpm run biome:check` · llms files pass the audit's exact regexes
- [x] Local `lighthouse@latest` agentic-browsing: 3/3 scored audits pass
- [ ] Post-deploy: PSI on deepworkplan.com → Agentic Browsing 3/3; SEO 100 after the Cloudflare dashboard change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
